### PR TITLE
v0.1.1-alpha

### DIFF
--- a/kubernetes/environments/production/main.tf
+++ b/kubernetes/environments/production/main.tf
@@ -28,10 +28,10 @@ module "eks" {
 }
 
 resource "aws_security_group_rule" "allow_bastion_to_eks" {
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = module.eks.additional_security_group_ids[0]
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = module.eks.eks_cluster_security_group_id
   source_security_group_id = module.security-groups.bastion_sg_id
 }

--- a/kubernetes/environments/production/main.tf
+++ b/kubernetes/environments/production/main.tf
@@ -24,5 +24,14 @@ module "eks" {
   cluster_version = var.cluster_version
   vpc_id = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnet_ids
-  bastion_key_name = var.bastion_key_name
+  additional_security_group_ids = [module.security-groups.additional_sg_id]
+}
+
+resource "aws_security_group_rule" "allow_bastion_to_eks" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = module.eks.additional_security_group_ids[0]
+  source_security_group_id = module.security-groups.bastion_sg_id
 }

--- a/kubernetes/modules/eks/main.tf
+++ b/kubernetes/modules/eks/main.tf
@@ -1,13 +1,13 @@
 # https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest
 
 module "eks" {
-  source = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
   version = "~> 20.0"
 
-  cluster_name = var.cluster_name
+  cluster_name    = var.cluster_name
   cluster_version = var.cluster_version
-  vpc_id = var.vpc_id
-  subnet_ids = var.subnet_ids
+  vpc_id          = var.vpc_id
+  subnet_ids      = var.subnet_ids
 
   cluster_endpoint_public_access  = true
   enable_cluster_creator_admin_permissions = true
@@ -34,4 +34,9 @@ module "eks" {
       capacity_type  = "SPOT"
     }
   }
+}
+
+output "eks_cluster_security_group_id" {
+  value       = module.eks.cluster_security_group_id
+  description = "The security group ID for the EKS cluster."
 }

--- a/kubernetes/modules/vpc/main.tf
+++ b/kubernetes/modules/vpc/main.tf
@@ -25,7 +25,7 @@ resource "aws_subnet" "public" {
   availability_zone = element(var.availability_zones, count.index)
   map_public_ip_on_launch = true
   tags = {
-    "kubernetes.io/role/elb" = 1
+    "kubernetes.io/role/alb" = 1
   }
 }
 


### PR DESCRIPTION
# Title

https://github.com/ByeongHunKim/Terraform/releases/tag/v0.1.0-alpha

에 명시한 부분 개선

3번
- eks cluster 추가 보안 그룹에 443 인바운드로 sg 수동으로 추가해야함 ( 이 부분 개선 필요함 )

6번
- subnet tag에 elb로 되어있는데 이거 때문에 elb가 생성된 것 인지 ( dev 클러스터의 traffic을 제대로 뜯어봐야 함 )



## Summary

## Major Changes
- 
-

## Detailed Description
- 
-

## Testing
1. 프로비저닝 했을 때 bastion host에서 클러스터 연결까지 수동 설정은 필요없음 ( aws configure 제외 )

## Related Issues
https://github.com/ByeongHunKim/Terraform/issues/8
https://github.com/ByeongHunKim/Terraform/issues/7
