### PR TITLE
v0.1.2-alpha : hotfix for v0.1.1-alpha bug

### DIFF
--- a/kubernetes/environments/production/main.tf
+++ b/kubernetes/environments/production/main.tf
@@ -24,7 +24,6 @@ module "eks" {
   cluster_version = var.cluster_version
   vpc_id = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnet_ids
-  additional_security_group_ids = [module.security-groups.additional_sg_id]
 }
 
 resource "aws_security_group_rule" "allow_bastion_to_eks" {

--- a/kubernetes/modules/eks/variables.tf
+++ b/kubernetes/modules/eks/variables.tf
@@ -17,8 +17,3 @@ variable "subnet_ids" {
   description = "The subnet IDs for the EKS cluster"
   type = list(string)
 }
-
-variable "bastion_key_name" {
-  description = "Key name for SSH access to the nodes"
-  type = string
-}


### PR DESCRIPTION
# Title
v0.1.2-alpha : hotfix for v0.1.1-alpha bug

## Summary
- v0.1.1-alpha 에서 terraform apply 하면 아래 issue에 있는 에러가 발생하여 수정

## Major Changes
- `environments/production/main.tf` 수정 : 필요없는 변수 제거
- `modules/eks/variables.tf` 수정 : 필요없는 bastion_key 변수 제거

## Testing
1. 해당 브랜치에서 terraform apply 후 프로비저닝 완료
2. Ansible에서 bastion으로 연결한 후 eks-initial-configuration.yml 실행했을 때 kubectl get nodes 명령어 수행 성공

## Related Issues
<!-- Link any related issues -->
[- closes #](https://github.com/ByeongHunKim/Terraform/issues/10)